### PR TITLE
Integrate new parent POM 3.1.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,6 +22,8 @@ logs/
 
 # Other
 **/.factorypath
+src/main/resources/discount_per_sample_size.csv
+.flattened-pom.xml
 
 # compiled Vaadin widgetsets
 src/main/webapp/VAADIN/widgetsets
@@ -35,3 +37,7 @@ src/main/webapp/WEB-INF/resourceFiles/*.csv
 
 # new properties file - do not push this ever
 src/main/resources/developer.properties
+
+
+
+

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,8 @@ branches:
   only:
   - master
   - development
+  - release\/.*
+  - hotfix\/.*
   # Travis treats pushed tags as branches
   - /^[vV]?\d+\.\d+\.\d+$/ # matches e.g., v1.2.3, 1.2.3, V1.2.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,8 @@ branches:
   - development
   - release\/.*
   - hotfix\/.*
-  # Travis treats pushed tags as branches
+  - feature\/.*
+    # Travis treats pushed tags as branches
   - /^[vV]?\d+\.\d+\.\d+$/ # matches e.g., v1.2.3, 1.2.3, V1.2.3
 
 # added to make logs look cleaner, crisper, certified fresh

--- a/pom.xml
+++ b/pom.xml
@@ -42,7 +42,7 @@
 			</snapshots>
 			<id>nexus-snapshots</id>
 			<name>QBiC Snapshots</name>
-			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-snapshots</url>
+			<url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-snapshots</url>
 		</repository>
 		<repository>
 			<releases>
@@ -55,7 +55,7 @@
 			</snapshots>
 			<id>nexus-releases</id>
 			<name>QBiC Releases</name>
-			<url>https://qbic-repo.am10.uni-tuebingen.de/repository/maven-releases</url>
+			<url>http://qbic-repo.qbic.uni-tuebingen.de:8081/repository/maven-releases</url>
 		</repository>
 	</repositories>
 
@@ -64,20 +64,19 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>portal-utils-lib</artifactId>
-			<version>1.6.0</version>
+			<version>2.2.1</version>
 		</dependency>
 
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>core-utils-lib</artifactId>
-			<version>1.1.0</version>
+			<version>1.7.0</version>
 		</dependency>
 		
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
 		</dependency>
-
 
 
 		<!-- Access to our custom databases (portlets use direct JDBC to access 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>life.qbic</groupId>
 		<artifactId>portlet-parent-pom</artifactId>
-		<version>1.4.0</version>
+		<version>3.1.0</version>
 	</parent>
 	<groupId>life.qbic</groupId>
 	<artifactId>qoffer-portlet</artifactId>
@@ -14,6 +14,16 @@
 	<url>http://github.com/qbicsoftware/qoffer</url>
 	<description>Allows the user to create offers, manage and print offers and create and manage packages for the offers.</description>
 	<packaging>war</packaging>
+	<properties>
+		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<maven.compiler.source>1.8</maven.compiler.source>
+		<maven.compiler.target>1.8</maven.compiler.target>
+		<vaadin.version>7.7.8</vaadin.version>
+		<vaadin.plugin.version>7.7.8</vaadin.plugin.version>
+		<liferay.version>6.2.5</liferay.version>
+		<liferay.maven.plugin.version>6.2.5</liferay.maven.plugin.version>
+		<jetty.plugin.version>9.4.31.v20200723</jetty.plugin.version>
+	</properties>
 	<!-- we only need to tell maven where to find our parent pom and other QBiC 
 		dependencies -->
 	<repositories>
@@ -66,7 +76,6 @@
 		<dependency>
 			<groupId>mysql</groupId>
 			<artifactId>mysql-connector-java</artifactId>
-			<version>5.1.6</version>
 		</dependency>
 
 
@@ -80,8 +89,9 @@
 		</dependency>
 
 		<dependency>
-			<groupId>life.qbic.openbis</groupId>
-			<artifactId>openbis_api</artifactId>
+			<groupId>life.qbic</groupId>
+			<artifactId>openbis-api</artifactId>
+			<version>18.06.2</version>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/org.vaadin.addons/vaadin-grid-util -->

--- a/src/main/java/life/qbic/dbase/OpenBisProxy.java
+++ b/src/main/java/life/qbic/dbase/OpenBisProxy.java
@@ -86,7 +86,7 @@ public class OpenBisProxy {
         final ConfigurationManager conf = ConfigurationManagerFactory.getInstance();
         password = conf.getDataSourcePassword();
         username = conf.getDataSourceUser();
-        url = conf.getDataSourceUrl() + "/openbis/openbis" + IApplicationServerApi.SERVICE_URL;
+      url = conf.getDataSourceUrl() + "/openbis/openbis" + IApplicationServerApi.SERVICE_URL;
         //LOG.info("OpenBIS URL {}",url);
 //      } else {
 //        try (final InputStream input = new FileInputStream(qOfferManagerUtils.PROPERTIES_FILE_PATH)) {

--- a/src/main/java/life/qbic/dbase/OpenBisProxy.java
+++ b/src/main/java/life/qbic/dbase/OpenBisProxy.java
@@ -86,7 +86,7 @@ public class OpenBisProxy {
         final ConfigurationManager conf = ConfigurationManagerFactory.getInstance();
         password = conf.getDataSourcePassword();
         username = conf.getDataSourceUser();
-      url = conf.getDataSourceUrl() + "/openbis/openbis" + IApplicationServerApi.SERVICE_URL;
+        url = conf.getDataSourceUrl() + "/openbis/openbis" + IApplicationServerApi.SERVICE_URL;
         //LOG.info("OpenBIS URL {}",url);
 //      } else {
 //        try (final InputStream input = new FileInputStream(qOfferManagerUtils.PROPERTIES_FILE_PATH)) {


### PR DESCRIPTION
New parent pom is integrated and also upgrades the MySQL java-connector dependency to 8.0.21.

The portlet is tested, though please also test the portlet to assure the functionality of such an important portlet. 
Furthermore, I did not update the nexus repository to our new instance since I don't want to break it, is this required @sven1103 ?