### PR TITLE
Downgrade portal-utils-lib

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -64,7 +64,7 @@
 		<dependency>
 			<groupId>life.qbic</groupId>
 			<artifactId>portal-utils-lib</artifactId>
-			<version>2.2.1</version>
+			<version>1.6.0</version>
 		</dependency>
 
 		<dependency>


### PR DESCRIPTION
The clash between Vaadin 8 in portal-utils-lib 2.2.1 and Vaadin 7 in qoffer itself leads to an internal server error while running the portlet. These two versions cannot be handled within one software. Therefore, I downgraded the version to 1.6.0 where Vaadin 7 was used.